### PR TITLE
Multi-period compatibility for cta profile

### DIFF
--- a/CrossValidation.php
+++ b/CrossValidation.php
@@ -109,7 +109,7 @@ function crossRepresentationProcess(){
         $adaptation_set = $adaptation_sets[$i];
 
         $file_path = str_replace('$AS$', $i, $adaptation_set_error_log_template) . '.txt';
-        $opfile = open_file($session_dir . '/' . $file_path, 'w');
+        $opfile = open_file($session_dir . '/Period' .$current_period.'/' . $file_path, 'w');
         
         $segmentAlignment = ($adaptation_set['segmentAlignment']) ? $adaptation_set['segmentAlignment'] : 'false';
         $subsegmentAlignment = ($adaptation_set['subsegmentAlignment']) ? $adaptation_set['subsegmentAlignment'] : 'false';
@@ -140,7 +140,7 @@ function crossRepresentationProcess(){
                     $timeoffset = $representation['presentationTimeOffset'];
 
                 $offsetmod = $timeoffset / $timescale;
-                $leafInfo[$j] = loadLeafInfoFile(str_replace(array('$AS$', '$R$'), array($i, $j), $reprsentation_info_log_template) . '.txt', $offsetmod);
+                $leafInfo[$j] = loadLeafInfoFile('Period' . $current_period . '/' . str_replace(array('$AS$', '$R$'), array($i, $j), $reprsentation_info_log_template) . '.txt', $offsetmod);
                 $leafInfo[$j]['id'] = $representation['id'];
             }
 
@@ -153,7 +153,7 @@ function crossRepresentationProcess(){
 
         close_file($opfile);
         $temp_string = str_replace('$Template$', explode('.', $file_path)[0], $string_info);
-        file_put_contents($session_dir . '/' . explode('.', $file_path)[0] . '.html', $temp_string);
-        print_console($session_dir . '/' . $file_path, "DASH Cross Validation Results for Adaptation Set $i");
+        file_put_contents($session_dir . '/Period' .$current_period.'/' . explode('.', $file_path)[0] . '.html', $temp_string);
+        print_console($session_dir . '/Period' .$current_period.'/' . $file_path, "Period " . ($current_period+1) . " Adaptation Set " . ($i+1) . " DASH Cross Validation Results");
     }
 }

--- a/MPDInfo.php
+++ b/MPDInfo.php
@@ -42,9 +42,8 @@ function current_period(){
     $AST = $mpd_features['availabilityStartTime'];
     
     if($mpd_features['type'] === 'static'){
-        $current_period = 0;
-        $start = $period_info[0][0];
-        $duration = $period_info[1][0];
+        $start = $period_info[0][$current_period];
+        $duration = $period_info[1][$current_period];
     }
     elseif($mpd_features['type'] === 'dynamic'){
         if(sizeof($mpd_features['Period']) == 1){


### PR DESCRIPTION
Normally, in our software we just process the first period in static MPD or the current period in dynamic MPD. In case CTA WAVE profile is enforced, then all the periods are processed. This is introduced for CTA cross-profile checks. This effort requires directory and file name changes within the whole software as well as loops considering each period. This commit contains the corresponding changes in this submodule.